### PR TITLE
Refactor: 비밀번호 찾기 연동 로직 수정 및 아이디, 비밀번호 찾은 뒤에 홈화면으로 이동하는 로직 추가 

### DIFF
--- a/src/components/Credential.vue
+++ b/src/components/Credential.vue
@@ -187,6 +187,8 @@ export default {
                 console.log('아이디 찾기: 인증번호 확인 성공', response.data);
                 this.displayMessage('id', `회원님의 아이디는 <strong>${response.data}</strong> 입니다.`, false);
                 this.idForm.showAuthInput = false; // 인증 성공 후 인증번호 입력칸 숨김
+                // Add a button to navigate to the home screen
+                this.idForm.message += `<br><button style="background-color: #4090e9; color: white; border: none; padding: 8px 12px; border-radius: 6px; cursor: pointer;" onclick="window.location.href='/'">홈으로 돌아가기</button>`;
             } catch (error) {
                 console.error('아이디 찾기: 인증번호 확인 실패', error.response ? error.response.data : error.message);
                 this.displayMessage('id', '인증번호가 올바르지 않습니다.', true);
@@ -261,6 +263,7 @@ export default {
                 this.displayMessage('pw', '비밀번호가 성공적으로 변경되었습니다.', false);
                 this.pwForm.showNewPasswordSection = false; // 변경 후 새 비밀번호 입력칸 숨김
                 this.resetForms(); // 폼 초기화
+                this.$router.push('/'); // 홈 화면으로 이동
             } catch (error) {
                 console.error('비밀번호 변경 실패', error.response ? error.response.data : error.message);
                 this.displayMessage('pw', '비밀번호 변경에 실패했습니다.', true);

--- a/src/components/LoginPage.vue
+++ b/src/components/LoginPage.vue
@@ -97,12 +97,12 @@ export default {
             this.$router.push("/signup");
         },
         goToFindId() {
-            alert("아이디 찾기 페이지로 이동합니다.");
-            // this.$router.push('/find-id');
+            // alert("아이디 찾기 페이지로 이동합니다.");
+            this.$router.push('/credential');
         },
         goToFindPassword() {
-            alert("비밀번호 찾기 페이지로 이동합니다.");
-            // this.$router.push('/find-password');
+            // alert("비밀번호 찾기 페이지로 이동합니다.");
+            this.$router.push('/credential');
         },
     },
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#11 

## 📝 작업 내용

1) 아이디 찾기 이후 홈화면으로 이동할 수 있는 버튼 추가 
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/056f3cb2-a7c3-4cd6-94fb-95f8e447afba" />

<br/>
<br/>

- 아이디 찾기 이후 홈화면으로 이동할 수 있는 버튼을 추가하여 로그인 화면으로 되돌아갈 수 있도록 로직을 추가했습니다.
- 비밀번호 찾기 기능에서는 검증 이후에 새로운 비밀번호를 입력하여 변경 버튼을 누르면 그와 동시에 로그인 화면으로 되돌아 가도록 로직을 추가했습니다.

<br/>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>