### PR TITLE
Fix: Vercel 배포 환경 404 오류 수정

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+    "rewrites": [
+        {
+            "source": "/((?!api|/_next/static|/_next/image|/favicon.ico).*)",
+            "destination": "/index.html"
+        }
+    ]
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#23 

## 📝 작업 내용
- Vercel 배포 이후, 메인 페이지(/)가 아닌 다른 경로 접근 시, 404 Not Fount 오류를 해결했습니다.
  - Vercel 서버가 해당 경로에 매칭되는 실제 파일을 찾지 못하여 발생하는 오류였습니다.
  - 프로젝트 루트에 vercel.json 설정 파일을 추가하여 index.html 파일로 응답할 수 있도록 하여 경로를 인식시켜줍니다.

- Vue & Vite 프로젝트는 기본적으로 SPA 방식으로 동작하는 프레임워크라는 것을 다시금 깨달았습니다.

<br/>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>